### PR TITLE
Test 'ros install sbcl' on Travis CI (DO NOT MERGE YET)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,9 @@ compiler:
   - gcc
   - clang
 
+before_script:
+  - sudo apt-get install -qq time
+
 script:
   - sh bootstrap
   - ./configure

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,4 @@ script:
   - ros --version
   - ros setup
   - ros run -- --version
+  - ros install sbcl

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ script:
   - ros --version
   - ros setup
   - ros run -- --version
-  - ros install sbcl
+  - ros install sbcl || $(cat ~/.roswell/impls/log/sbcl-1.2.7/make.log && exit -1)


### PR DESCRIPTION
When I added `ros install sbcl` to .travis.yml, it raises an error at `sh install.sh` on Travis CI.

https://travis-ci.org/fukamachi/roswell/jobs/46989284#L324

As I never seen the error even on Linux machines, I thought it is an error raised only on Travis CI. However, my coworker encountered the exact same error on EC2 while he was trying to deploy.

Any thoughts?