### PR TITLE
Fix non-malloced area free issue(#25)

### DIFF
--- a/src/cmd-run-ccl.c
+++ b/src/cmd-run-ccl.c
@@ -41,7 +41,7 @@ char** cmd_run_ccl(int argc,char** argv,struct sub_command* cmd)
   if(issystem){
     bin=truename(which("ccl"));
   }else {
-    bin=s_cat(impl_path,SLASH,ccl_binname(),q(EXE_EXTENTION),NULL);
+    bin=s_cat(impl_path,q(SLASH),ccl_binname(),q(EXE_EXTENTION),NULL);
   }
 
   if(script)


### PR DESCRIPTION
I cannot get memory issue with this patch.
(However I got another error)

```
% ros -v run -- --version                                                                                                                             
opt_verbose:verbose 1
proccmd:run
cmd_run:argc=3 argv[0]=run
proccmd:--
cmd_run_star: argc=2 argv[0]=-- 
localopt:(("homedir""/home/syohei/.roswell/")("argv0""ros")("quicklisp""/home/syohei/.roswell/impls/ALL/ALL/quicklisp/"))
args /home/syohei/.roswell/impls/x86-64/linux/ccl-bin/1.10/lx86cl64 --no-init --quiet --batch --image-name ���/lx86cl64.image --eval (progn #-ros.init(cl:load "/usr/local/share/common-lisp/source/roswell/init.lisp")) --eval (progn #-quicklisp(cl:load "/home/syohei/.roswell/impls/ALL/ALL/quicklisp/setup.lisp")) --version 
ROS_OPTS (("impl""ccl-bin/1.10")("homedir""/home/syohei/.roswell/")("argv0""ros")("quicklisp""/home/syohei/.roswell/impls/ALL/ALL/quicklisp/"))
Couldn't load lisp heap image from ���/lx86cl64.image: No such file or directory
```
