### PR TITLE
Allow relative pathname as --source-registry option

### DIFF
--- a/src/lisp/init.lisp
+++ b/src/lisp/init.lisp
@@ -56,7 +56,10 @@
 
 (defun source-registry (cmd arg &rest rest)
   (declare (ignorable cmd rest))
-  (asdf:initialize-source-registry arg))
+  (let ((dir (probe-file arg)))
+    (if dir
+        (asdf:initialize-source-registry dir)
+        (warn "Directory ~S doesn't exist. Ignored." arg))))
 
 (defun system (cmd arg &rest rest)
   (declare (ignorable cmd rest))


### PR DESCRIPTION
I wanted add the cwd to the source registry, however this invokes a debugger at the latest version.

```
$ ros -S . -e '(princ "hi")'

debugger invoked on a SIMPLE-ERROR in thread
#<THREAD "main thread" RUNNING {100300F793}>:
  source-registry string must specify absolute pathnames: "."

Type HELP for debugger help, or (SB-EXT:EXIT) to exit from SBCL.

restarts (invokable by number or by possibly-abbreviated name):
  0: [CONTINUE] Ignore runtime option --eval "(ros:run '((:source-registry \".\")(:eval \"(princ \\\"hi\\\")\")(:quit)))".
  1: [ABORT   ] Skip rest of --eval and --load options.
  2:            Skip to toplevel READ/EVAL/PRINT loop.
  3: [EXIT    ] Exit SBCL (calling #'EXIT, killing the process).

((FLET ASDF/SOURCE-REGISTRY::CHECK :IN ASDF/SOURCE-REGISTRY:PARSE-SOURCE-REGISTRY-STRING) ".")
0] * 
```

This pull request would fix the problem.