### PR TITLE
Kind error messages of ros:exec

### DIFF
--- a/src/lisp/init.lisp
+++ b/src/lisp/init.lisp
@@ -39,7 +39,8 @@
                          item))
              (when (minusp
                     (%execvp program a-args))
-               (error "execvp(3) returned.")))
+               (error "execvp(3) failed. (Code=~D)"
+                      (sb-impl::get-errno))))
         (sb-alien:free-alien a-args)))))
 
 (defun setenv (name value)

--- a/src/lisp/init.lisp
+++ b/src/lisp/init.lisp
@@ -29,6 +29,8 @@
 
   (defun execvp (program args)
     "Replace current executable with another one."
+    (unless (probe-file program)
+      (error "Cannot exec ~S: No such file or directory" program))
     (let ((a-args (sb-alien:make-alien sb-alien:c-string
                                        (+ 1 (length args)))))
       (unwind-protect


### PR DESCRIPTION
`ros:exec` shows an error message "execvp(3) returned." but it's not helpful.

* Show `errno` in the message
* Show "No such file or directory" when the file trying to execute is not found