### PR TITLE
Check if 'sudo' is required or not in scripts/install-for-ci.sh.

### DIFF
--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -20,7 +20,11 @@ cd $ROSWELL_DIR
 sh bootstrap
 ./configure --prefix=$ROSWELL_INSTALL_DIR
 make
-sudo make install
+if [ -w "$ROSWELL_INSTALL_DIR" ]; then
+    make install
+else
+    sudo make install
+fi
 
 echo "Roswell has been installed."
 log "ros --version"


### PR DESCRIPTION
This change makes it doesn't require 'sudo' on CI services by setting ROSWELL_INSTALL_DIR to a user local directory.
Make sure $ROSWELL_INSTALL_DIR/bin is in PATH for 'ros' command.