### PR TITLE
Allow to specify LISP other than sbcl or ccl for CI.

### DIFF
--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -30,15 +30,17 @@ echo "Roswell has been installed."
 log "ros --version"
 
 case "$LISP" in
+    # 'ccl' is an alias for 'ccl-bin'
     ccl)
-        echo "Installing Clozure CL..."
-        ros install ccl-bin
+        LISP=ccl-bin
         ;;
-    sbcl|*)
-        echo "Installing SBCL..."
-        ros install sbcl-bin
+    # 'sbcl-bin' is the default
+    "")
+        LISP=sbcl-bin
         ;;
 esac
+echo "Installing $LISP..."
+ros install $LISP
 
 ros -e '(format t "~&~A ~A up and running! (ASDF ~A)~2%"
                 (lisp-implementation-type)


### PR DESCRIPTION
This allows to specify `$LISP` other than "sbcl" or "ccl" for CI services.
Assuming that you're working on adding Lisp implementation to support, this makes it possible to take advantage of it.

This also allows to include Lisp versions in `$LISP` like `sbcl/1.0.55` or `clisp/2.49`.

Let me know when Roswell is ready to try other implementations to use. I'm looking forward to trying it on Travis CI :grinning: 