### PR TITLE
[WIP] Adding system Lisp implementation support for CI

### DIFF
--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -5,6 +5,22 @@ log () {
     echo `$1`
 }
 
+fetch () {
+    echo "Downloading $1..."
+    if curl --no-progress-bar --retry 10 -o $2 -L $1; then
+        return 0;
+    else
+        echo "Failed to download $1."
+        exit 1
+    fi
+}
+
+extract () {
+    echo "Extracting a tarball $1 into $2..."
+    mkdir -p $2
+    tar -C $2 --strip-components 1 -xf $1
+}
+
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
 ROSWELL_DIR=$HOME/roswell
 ROSWELL_REPO=${ROSWELL_REPO:-https://github.com/snmsts/roswell}
@@ -13,9 +29,8 @@ ROSWELL_INSTALL_DIR=${ROSWELL_INSTALL_DIR:-/usr/local/}
 
 echo "Installing Roswell..."
 
-curl --no-progress-bar --retry 10 -o $ROSWELL_TARBALL_PATH -L $ROSWELL_REPO/archive/$ROSWELL_BRANCH.tar.gz
-mkdir $ROSWELL_DIR
-tar -C $ROSWELL_DIR --strip-components 1 -xf $ROSWELL_TARBALL_PATH
+fetch "$ROSWELL_REPO/archive/$ROSWELL_BRANCH.tar.gz" $ROSWELL_TARBALL_PATH
+extract $ROSWELL_TARBALL_PATH $ROSWELL_DIR
 cd $ROSWELL_DIR
 sh bootstrap
 ./configure --prefix=$ROSWELL_INSTALL_DIR

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -39,8 +39,17 @@ case "$LISP" in
         LISP=sbcl-bin
         ;;
 esac
+
 echo "Installing $LISP..."
-ros install $LISP
+case "$LISP" in
+    clisp)
+        sudo apt-get install clisp
+        ros use clisp/system
+        ;;
+    *)
+        ros install $LISP
+        ;;
+esac
 
 ros -e '(format t "~&~A ~A up and running! (ASDF ~A)~2%"
                 (lisp-implementation-type)

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -5,7 +5,13 @@ log () {
     echo `$1`
 }
 
-LISP_IMPLS_BIN="$HOME/.roswell/bin"
+ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
+ROSWELL_DIR=$HOME/roswell
+ROSWELL_REPO=${ROSWELL_REPO:-https://github.com/snmsts/roswell}
+ROSWELL_BRANCH=${ROSWELL_BRANCH:-release}
+ROSWELL_INSTALL_DIR=${ROSWELL_INSTALL_DIR:-/usr/local/}
+LISP_IMPLS_DIR="$ROSWELL_DIR/impls/system"
+LISP_IMPLS_BIN="$ROSWELL_DIR/bin"
 
 fetch () {
     echo "Downloading $1..."
@@ -52,59 +58,62 @@ apt_unless_installed () {
 
 CMU_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.tar.bz2"
 CMU_EXTRA_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.extra.tar.bz2"
-CMU_DIR="$HOME/cmucl"
+CMU_DIR="$LISP_IMPLS_DIR/cmucl"
 install_cmucl () {
-    fetch "$CMU_TARBALL_URL" "$HOME/cmucl.tar.bz2"
-    extract -j "$HOME/cmucl.tar.bz2" "$CMU_DIR"
-    fetch "$CMU_EXTRA_TARBALL_URL" "$HOME/cmucl-extra.tar.bz2"
-    extract -j "$HOME/cmucl-extra.tar.bz2" "$CMU_DIR"
+    if ! [ -f "$LISP_IMPLS_BIN/cmucl" ]; then
+        fetch "$CMU_TARBALL_URL" "$HOME/cmucl.tar.bz2"
+        extract -j "$HOME/cmucl.tar.bz2" "$CMU_DIR"
+        fetch "$CMU_EXTRA_TARBALL_URL" "$HOME/cmucl-extra.tar.bz2"
+        extract -j "$HOME/cmucl-extra.tar.bz2" "$CMU_DIR"
 
-    export CMUCLLIB="$CMU_DIR/lib/cmucl/lib"
-    install_script "$LISP_IMPLS_BIN/cmucl" \
-        "export CMUCLLIB=\"$CMU_DIR/lib/cmucl/lib\"" \
-        "exec \"$CMU_DIR/bin/lisp\" \"\$@\""
+        export CMUCLLIB="$CMU_DIR/lib/cmucl/lib"
+        install_script "$LISP_IMPLS_BIN/cmucl" \
+            "export CMUCLLIB=\"$CMU_DIR/lib/cmucl/lib\"" \
+            "exec \"$CMU_DIR/bin/lisp\" \"\$@\""
+    fi
     PATH="$LISP_IMPLS_BIN:$PATH" ros use cmucl/system
 }
 
 ABCL_TARBALL_URL="https://common-lisp.net/project/armedbear/releases/1.3.2/abcl-bin-1.3.2.tar.gz"
-ABCL_DIR="$HOME/abcl"
+ABCL_DIR="$LISP_IMPLS_DIR/abcl"
 install_abcl () {
-    apt_unless_installed default-jre
-    fetch "$ABCL_TARBALL_URL" "$HOME/abcl.tar.gz"
-    extract -z "$HOME/abcl.tar.gz" "$ABCL_DIR"
-    install_script "$LISP_IMPLS_BIN/abcl" \
-        "exec java -cp \"$ABCL_DIR/abcl-contrib.jar\" -jar \"$ABCL_DIR/abcl.jar\" \"\$@\""
+    if ! [ -f "$LISP_IMPLS_BIN/abcl" ]; then
+        apt_unless_installed default-jre
+        fetch "$ABCL_TARBALL_URL" "$HOME/abcl.tar.gz"
+        extract -z "$HOME/abcl.tar.gz" "$ABCL_DIR"
+        install_script "$LISP_IMPLS_BIN/abcl" \
+            "exec java -cp \"$ABCL_DIR/abcl-contrib.jar\" -jar \"$ABCL_DIR/abcl.jar\" \"\$@\""
+    fi
     PATH="$LISP_IMPLS_BIN:$PATH" ros use abcl/system
 }
 
 ECL_TARBALL_URL="http://downloads.sourceforge.net/project/ecls/ecls/15.3/ecl-15.3.7.tgz"
-ECL_DIR="$HOME/ecl"
+ECL_DIR="$LISP_IMPLS_DIR/ecl"
 install_ecl () {
-    fetch "$ECL_TARBALL_URL" "$HOME/ecl.tgz"
-    extract -z "$HOME/ecl.tgz" "$HOME/ecl-src"
-    cd $HOME/ecl-src
-    ./configure --prefix="$ECL_DIR"
-    make
-    make install
-    install_script "$LISP_IMPLS_BIN/ecl" \
-        "exec \"$ECL_DIR/bin/ecl\" \"\$@\""
+    if ! [ -f "$LISP_IMPLS_BIN/ecl" ]; then
+        fetch "$ECL_TARBALL_URL" "$HOME/ecl.tgz"
+        extract -z "$HOME/ecl.tgz" "$HOME/ecl-src"
+        cd $HOME/ecl-src
+        ./configure --prefix="$ECL_DIR"
+        make
+        make install
+        install_script "$LISP_IMPLS_BIN/ecl" \
+            "exec \"$ECL_DIR/bin/ecl\" \"\$@\""
+    fi
     PATH="$LISP_IMPLS_BIN:$PATH" ros use ecl/system
 }
 
 ALLEGRO_TARBALL_URL="http://www.franz.com/ftp/pub/acl90express/linux86/acl90express-linux-x86.bz2"
+ALLEGRO_DIR="$LISP_IMPLS_DIR/acl"
 install_allegro () {
-    fetch "$ALLEGRO_TARBALL_URL" "$HOME/acl.bz2"
-    extract -j "$HOME/acl.bz2" "$HOME/acl"
-    install_script "$LISP_IMPLS_BIN/alisp" \
-        "exec \"$HOME/acl/alisp\" \"\$@\""
+    if ! [ -f "$LISP_IMPLS_BIN/alisp" ]; then
+        fetch "$ALLEGRO_TARBALL_URL" "$HOME/acl.bz2"
+        extract -j "$HOME/acl.bz2" "$ALLEGRO_DIR"
+        install_script "$LISP_IMPLS_BIN/alisp" \
+            "exec \"$ALLEGRO_DIR/alisp\" \"\$@\""
+    fi
     PATH="$LISP_IMPLS_BIN:$PATH" ros use alisp/system
 }
-
-ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
-ROSWELL_DIR=$HOME/roswell
-ROSWELL_REPO=${ROSWELL_REPO:-https://github.com/snmsts/roswell}
-ROSWELL_BRANCH=${ROSWELL_BRANCH:-release}
-ROSWELL_INSTALL_DIR=${ROSWELL_INSTALL_DIR:-/usr/local/}
 
 echo "Installing Roswell..."
 

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -16,14 +16,9 @@ fetch () {
 }
 
 extract () {
-    if [ "$3" = "" ]; then
-        file=$1
-        destination=$2
-    else
-        opt=$1
-        file=$2
-        destination=$3
-    fi
+    opt=$1
+    file=$2
+    destination=$3
     echo "Extracting a tarball $file into $destination..."
     mkdir -p $destination
     tar -C $destination --strip-components=1 -xf $opt $file
@@ -33,9 +28,9 @@ CMU_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/
 CMU_EXTRA_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.extra.tar.bz2"
 install_cmucl () {
     fetch $CMU_TARBALL_URL $HOME/cmucl.tar.bz2
-    extract $HOME/cmucl.tar.bz2 $HOME/cmucl
+    extract -j $HOME/cmucl.tar.bz2 $HOME/cmucl
     fetch $CMU_EXTRA_TARBALL_URL $HOME/cmucl-extra.tar.bz2
-    extract $HOME/cmucl-extra.tar.bz2 $HOME/cmucl
+    extract -j $HOME/cmucl-extra.tar.bz2 $HOME/cmucl
 
     export CMUCLLIB="$HOME/cmucl/lib/cmucl/lib"
     sudo ln -s "$HOME/cmucl/bin/lisp" "/usr/local/bin/cmucl"
@@ -67,7 +62,7 @@ ROSWELL_INSTALL_DIR=${ROSWELL_INSTALL_DIR:-/usr/local/}
 echo "Installing Roswell..."
 
 fetch "$ROSWELL_REPO/archive/$ROSWELL_BRANCH.tar.gz" $ROSWELL_TARBALL_PATH
-extract $ROSWELL_TARBALL_PATH $ROSWELL_DIR
+extract -j $ROSWELL_TARBALL_PATH $ROSWELL_DIR
 cd $ROSWELL_DIR
 sh bootstrap
 ./configure --prefix=$ROSWELL_INSTALL_DIR

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -20,17 +20,17 @@ extract () {
     file=$2
     destination=$3
     echo "Extracting a tarball $file into $destination..."
-    mkdir -p $destination
-    tar -C $destination --strip-components=1 -xf $opt $file
+    mkdir -p "$destination"
+    tar -C "$destination" --strip-components=1 "$opt" -xf "$file"
 }
 
 CMU_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.tar.bz2"
 CMU_EXTRA_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.extra.tar.bz2"
 install_cmucl () {
-    fetch $CMU_TARBALL_URL $HOME/cmucl.tar.bz2
-    extract -j $HOME/cmucl.tar.bz2 $HOME/cmucl
-    fetch $CMU_EXTRA_TARBALL_URL $HOME/cmucl-extra.tar.bz2
-    extract -j $HOME/cmucl-extra.tar.bz2 $HOME/cmucl
+    fetch "$CMU_TARBALL_URL" "$HOME/cmucl.tar.bz2"
+    extract -j "$HOME/cmucl.tar.bz2" "$HOME/cmucl"
+    fetch "$CMU_EXTRA_TARBALL_URL" "$HOME/cmucl-extra.tar.bz2"
+    extract -j "$HOME/cmucl-extra.tar.bz2" "$HOME/cmucl"
 
     export CMUCLLIB="$HOME/cmucl/lib/cmucl/lib"
     sudo ln -s "$HOME/cmucl/bin/lisp" "/usr/local/bin/cmucl"
@@ -39,8 +39,8 @@ install_cmucl () {
 ABCL_TARBALL_URL="https://common-lisp.net/project/armedbear/releases/1.3.2/abcl-bin-1.3.2.tar.gz"
 install_abcl () {
     sudo apt-get install default-jre
-    fetch $ABCL_TARBALL_URL $HOME/abcl.tar.bz2
-    extract -z $HOME/abcl.tar.bz2 $HOME/abcl
+    fetch "$ABCL_TARBALL_URL" "$HOME/abcl.tar.bz2"
+    extract -z "$HOME/abcl.tar.bz2" "$HOME/abcl"
     sudo cat <<EOF >/usr/local/bin/abcl
 #!/bin/sh
 java -cp \"$HOME/abcl/abcl-contrib.jar\" -jar \"$HOME/abcl/abcl.jar\" \"\$@\"
@@ -49,8 +49,8 @@ EOF
 
 ECL_TARBALL_URL="http://downloads.sourceforge.net/project/ecls/ecls/15.3/ecl-15.3.7.tgz"
 install_ecl () {
-    fetch $ECL_TARBALL_URL $HOME/ecl.tgz
-    sudo tar -C / -xzf $HOME/ecl.tgz
+    fetch "$ECL_TARBALL_URL" "$HOME/ecl.tgz"
+    sudo tar -C / -xzf "$HOME/ecl.tgz"
 }
 
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
@@ -61,8 +61,8 @@ ROSWELL_INSTALL_DIR=${ROSWELL_INSTALL_DIR:-/usr/local/}
 
 echo "Installing Roswell..."
 
-fetch "$ROSWELL_REPO/archive/$ROSWELL_BRANCH.tar.gz" $ROSWELL_TARBALL_PATH
-extract -j $ROSWELL_TARBALL_PATH $ROSWELL_DIR
+fetch "$ROSWELL_REPO/archive/$ROSWELL_BRANCH.tar.gz" "$ROSWELL_TARBALL_PATH"
+extract -j "$ROSWELL_TARBALL_PATH" "$ROSWELL_DIR"
 cd $ROSWELL_DIR
 sh bootstrap
 ./configure --prefix=$ROSWELL_INSTALL_DIR

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -53,7 +53,8 @@ install_abcl () {
     sudo apt-get install default-jre
     fetch "$ABCL_TARBALL_URL" "$HOME/abcl.tar.gz"
     extract -z "$HOME/abcl.tar.gz" "$HOME/abcl"
-    install_script "#!/bin/sh" \
+    install_script "/usr/local/bin/abcl" \
+        "#!/bin/sh" \
         "java -cp \"$HOME/abcl/abcl-contrib.jar\" -jar \"$HOME/abcl/abcl.jar\" \"\$@\""
 }
 

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -5,7 +5,7 @@ log () {
     echo `$1`
 }
 
-LISP_IMPLS_PREFIX=${LISP_IMPLS_PREFIX:-/usr/local}
+LISP_IMPLS_BIN="$HOME/.roswell/bin"
 
 fetch () {
     echo "Downloading $1..."
@@ -60,9 +60,10 @@ install_cmucl () {
     extract -j "$HOME/cmucl-extra.tar.bz2" "$CMU_DIR"
 
     export CMUCLLIB="$CMU_DIR/lib/cmucl/lib"
-    install_script "$LISP_IMPLS_PREFIX/bin/cmucl" \
+    install_script "$LISP_IMPLS_BIN/cmucl" \
         "export CMUCLLIB=\"$CMU_DIR/lib/cmucl/lib\"" \
         "exec \"$CMU_DIR/bin/lisp\" \"\$@\""
+    PATH="$LISP_IMPLS_BIN:$PATH" ros use cmucl/system
 }
 
 ABCL_TARBALL_URL="https://common-lisp.net/project/armedbear/releases/1.3.2/abcl-bin-1.3.2.tar.gz"
@@ -71,8 +72,9 @@ install_abcl () {
     apt_unless_installed default-jre
     fetch "$ABCL_TARBALL_URL" "$HOME/abcl.tar.gz"
     extract -z "$HOME/abcl.tar.gz" "$ABCL_DIR"
-    install_script "$LISP_IMPLS_PREFIX/bin/abcl" \
+    install_script "$LISP_IMPLS_BIN/abcl" \
         "exec java -cp \"$ABCL_DIR/abcl-contrib.jar\" -jar \"$ABCL_DIR/abcl.jar\" \"\$@\""
+    PATH="$LISP_IMPLS_BIN:$PATH" ros use abcl/system
 }
 
 ECL_TARBALL_URL="http://downloads.sourceforge.net/project/ecls/ecls/15.3/ecl-15.3.7.tgz"
@@ -84,16 +86,18 @@ install_ecl () {
     ./configure --prefix="$ECL_DIR"
     make
     make install
-    install_script "$LISP_IMPLS_PREFIX/bin/ecl" \
+    install_script "$LISP_IMPLS_BIN/ecl" \
         "exec \"$ECL_DIR/bin/ecl\" \"\$@\""
+    PATH="$LISP_IMPLS_BIN:$PATH" ros use ecl/system
 }
 
 ALLEGRO_TARBALL_URL="http://www.franz.com/ftp/pub/acl90express/linux86/acl90express-linux-x86.bz2"
 install_allegro () {
     fetch "$ALLEGRO_TARBALL_URL" "$HOME/acl.bz2"
     extract -j "$HOME/acl.bz2" "$HOME/acl"
-    install_script "$LISP_IMPLS_PREFIX/bin/alisp" \
+    install_script "$LISP_IMPLS_BIN/alisp" \
         "exec \"$HOME/acl/alisp\" \"\$@\""
+    PATH="$LISP_IMPLS_BIN:$PATH" ros use alisp/system
 }
 
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
@@ -138,19 +142,15 @@ case "$LISP" in
         ;;
     cmu|cmucl)
         install_cmucl
-        ros use cmucl/system
         ;;
     abcl)
         install_abcl
-        ros use abcl/system
         ;;
     ecl)
         install_ecl
-        ros use ecl/system
         ;;
     allegro|alisp)
         install_allegro
-        ros use alisp/system
         ;;
     *)
         ros install $LISP

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -63,6 +63,13 @@ install_ecl () {
     sudo tar -C / -xzf "$HOME/ecl.tgz"
 }
 
+ALLEGRO_TARBALL_URL="http://www.franz.com/ftp/pub/acl90express/linux86/acl90express-linux-x86.bz2"
+install_allegro () {
+    fetch "$ALLEGRO_TARBALL_URL" "$HOME/acl.bz2"
+    extract -j "$HOME/acl.bz2" "$HOME/acl"
+    sudo ln -s "$HOME/acl/alisp" "/usr/local/bin"
+}
+
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
 ROSWELL_DIR=$HOME/roswell
 ROSWELL_REPO=${ROSWELL_REPO:-https://github.com/snmsts/roswell}
@@ -114,6 +121,10 @@ case "$LISP" in
     ecl)
         install_ecl
         ros use ecl/system
+        ;;
+    allegro|alisp)
+        install_allegro
+        ros use alisp/system
         ;;
     *)
         ros install $LISP

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -41,6 +41,17 @@ install_cmucl () {
     sudo ln -s "$HOME/cmucl/bin/lisp" "/usr/local/bin/cmucl"
 }
 
+ABCL_TARBALL_URL="https://common-lisp.net/project/armedbear/releases/1.3.2/abcl-bin-1.3.2.tar.gz"
+install_abcl () {
+    sudo apt-get install default-jre
+    fetch $ABCL_TARBALL_URL $HOME/abcl.tar.bz2
+    extract -z $HOME/abcl.tar.bz2 $HOME/abcl
+    sudo cat <<EOF >/usr/local/bin/abcl
+#!/bin/sh
+java -cp \"$HOME/abcl/abcl-contrib.jar\" -jar \"$HOME/abcl/abcl.jar\" \"\$@\"
+EOF
+}
+
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
 ROSWELL_DIR=$HOME/roswell
 ROSWELL_REPO=${ROSWELL_REPO:-https://github.com/snmsts/roswell}
@@ -84,6 +95,10 @@ case "$LISP" in
     cmu|cmucl)
         install_cmucl
         ros use cmucl/system
+        ;;
+    abcl)
+        install_abcl
+        ros use abcl/system
         ;;
     *)
         ros install $LISP

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -52,39 +52,40 @@ apt_unless_installed () {
 
 CMU_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.tar.bz2"
 CMU_EXTRA_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.extra.tar.bz2"
+CMU_DIR="$HOME/cmucl"
 install_cmucl () {
     fetch "$CMU_TARBALL_URL" "$HOME/cmucl.tar.bz2"
-    extract -j "$HOME/cmucl.tar.bz2" "$HOME/cmucl"
+    extract -j "$HOME/cmucl.tar.bz2" "$CMU_DIR"
     fetch "$CMU_EXTRA_TARBALL_URL" "$HOME/cmucl-extra.tar.bz2"
-    extract -j "$HOME/cmucl-extra.tar.bz2" "$HOME/cmucl"
+    extract -j "$HOME/cmucl-extra.tar.bz2" "$CMU_DIR"
 
-    export CMUCLLIB="$HOME/cmucl/lib/cmucl/lib"
+    export CMUCLLIB="$CMU_DIR/lib/cmucl/lib"
     install_script "$LISP_IMPLS_PREFIX/bin/cmucl" \
-        "export CMUCLLIB=\"$HOME/cmucl/lib/cmucl/lib\"" \
-        "exec \"$HOME/cmucl/bin/lisp\" \"\$@\""
+        "export CMUCLLIB=\"$CMU_DIR/lib/cmucl/lib\"" \
+        "exec \"$CMU_DIR/bin/lisp\" \"\$@\""
 }
 
 ABCL_TARBALL_URL="https://common-lisp.net/project/armedbear/releases/1.3.2/abcl-bin-1.3.2.tar.gz"
+ABCL_DIR="$HOME/abcl"
 install_abcl () {
     apt_unless_installed default-jre
     fetch "$ABCL_TARBALL_URL" "$HOME/abcl.tar.gz"
-    extract -z "$HOME/abcl.tar.gz" "$HOME/abcl"
+    extract -z "$HOME/abcl.tar.gz" "$ABCL_DIR"
     install_script "$LISP_IMPLS_PREFIX/bin/abcl" \
-        "exec java -cp \"$HOME/abcl/abcl-contrib.jar\" -jar \"$HOME/abcl/abcl.jar\" \"\$@\""
+        "exec java -cp \"$ABCL_DIR/abcl-contrib.jar\" -jar \"$ABCL_DIR/abcl.jar\" \"\$@\""
 }
 
 ECL_TARBALL_URL="http://downloads.sourceforge.net/project/ecls/ecls/15.3/ecl-15.3.7.tgz"
+ECL_DIR="$HOME/ecl"
 install_ecl () {
     fetch "$ECL_TARBALL_URL" "$HOME/ecl.tgz"
-    extract -z "$HOME/ecl.tgz" "$HOME/ecl"
-    cd $HOME/ecl
-    ./configure --prefix="$LISP_IMPLS_PREFIX"
+    extract -z "$HOME/ecl.tgz" "$HOME/ecl-src"
+    cd $HOME/ecl-src
+    ./configure --prefix="$ECL_DIR"
     make
-    if [ -w "$LISP_IMPLS_PREFIX" ]; then
-        make install
-    else
-        sudo make install
-    fi
+    make install
+    install_script "$LISP_IMPLS_PREFIX/bin/ecl" \
+        "exec \"$ECL_DIR/bin/ecl\" \"\$@\""
 }
 
 ALLEGRO_TARBALL_URL="http://www.franz.com/ftp/pub/acl90express/linux86/acl90express-linux-x86.bz2"

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -39,8 +39,8 @@ install_cmucl () {
 ABCL_TARBALL_URL="https://common-lisp.net/project/armedbear/releases/1.3.2/abcl-bin-1.3.2.tar.gz"
 install_abcl () {
     sudo apt-get install default-jre
-    fetch "$ABCL_TARBALL_URL" "$HOME/abcl.tar.bz2"
-    extract -z "$HOME/abcl.tar.bz2" "$HOME/abcl"
+    fetch "$ABCL_TARBALL_URL" "$HOME/abcl.tar.gz"
+    extract -z "$HOME/abcl.tar.gz" "$HOME/abcl"
     sudo cat <<EOF >/usr/local/bin/abcl
 #!/bin/sh
 java -cp \"$HOME/abcl/abcl-contrib.jar\" -jar \"$HOME/abcl/abcl.jar\" \"\$@\"
@@ -62,7 +62,7 @@ ROSWELL_INSTALL_DIR=${ROSWELL_INSTALL_DIR:-/usr/local/}
 echo "Installing Roswell..."
 
 fetch "$ROSWELL_REPO/archive/$ROSWELL_BRANCH.tar.gz" "$ROSWELL_TARBALL_PATH"
-extract -j "$ROSWELL_TARBALL_PATH" "$ROSWELL_DIR"
+extract -z "$ROSWELL_TARBALL_PATH" "$ROSWELL_DIR"
 cd $ROSWELL_DIR
 sh bootstrap
 ./configure --prefix=$ROSWELL_INSTALL_DIR

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -16,9 +16,29 @@ fetch () {
 }
 
 extract () {
-    echo "Extracting a tarball $1 into $2..."
-    mkdir -p $2
-    tar -C $2 --strip-components 1 -xf $1
+    if $3; then
+        opt=$1
+        file=$2
+        destination=$3
+    else
+        file=$1
+        destination=$2
+    fi
+    echo "Extracting a tarball $file into $destination..."
+    mkdir -p $destination
+    tar -C $destination --strip-components=1 -xf $opt $file
+}
+
+CMU_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.tar.bz2"
+CMU_EXTRA_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.extra.tar.bz2"
+install_cmucl () {
+    fetch $CMU_TARBALL_URL $HOME/cmucl.tar.bz2
+    extract -j $HOME/cmucl.tar.bz2 $HOME/cmucl
+    fetch $CMU_EXTRA_TARBALL_URL $HOME/cmucl-extra.tar.bz2
+    extract $HOME/cmucl-extra.tar.bz2 $HOME/cmucl
+
+    export CMUCLLIB="$HOME/cmucl/lib/cmucl/lib"
+    sudo ln -s "$HOME/cmucl/bin/lisp" "/usr/local/bin/cmucl"
 }
 
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
@@ -60,6 +80,10 @@ case "$LISP" in
     clisp)
         sudo apt-get install clisp
         ros use clisp/system
+        ;;
+    cmu|cmucl)
+        install_cmucl
+        ros use cmucl/system
         ;;
     *)
         ros install $LISP

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -16,13 +16,13 @@ fetch () {
 }
 
 extract () {
-    if $3; then
+    if [ "$3" = "" ]; then
+        file=$1
+        destination=$2
+    else
         opt=$1
         file=$2
         destination=$3
-    else
-        file=$1
-        destination=$2
     fi
     echo "Extracting a tarball $file into $destination..."
     mkdir -p $destination
@@ -33,7 +33,7 @@ CMU_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/
 CMU_EXTRA_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.extra.tar.bz2"
 install_cmucl () {
     fetch $CMU_TARBALL_URL $HOME/cmucl.tar.bz2
-    extract -j $HOME/cmucl.tar.bz2 $HOME/cmucl
+    extract $HOME/cmucl.tar.bz2 $HOME/cmucl
     fetch $CMU_EXTRA_TARBALL_URL $HOME/cmucl-extra.tar.bz2
     extract $HOME/cmucl-extra.tar.bz2 $HOME/cmucl
 

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -52,6 +52,12 @@ java -cp \"$HOME/abcl/abcl-contrib.jar\" -jar \"$HOME/abcl/abcl.jar\" \"\$@\"
 EOF
 }
 
+ECL_TARBALL_URL="http://downloads.sourceforge.net/project/ecls/ecls/15.3/ecl-15.3.7.tgz"
+install_ecl () {
+    fetch $ECL_TARBALL_URL $HOME/ecl.tgz
+    sudo tar -C / -xzf $HOME/ecl.tgz
+}
+
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz
 ROSWELL_DIR=$HOME/roswell
 ROSWELL_REPO=${ROSWELL_REPO:-https://github.com/snmsts/roswell}
@@ -99,6 +105,10 @@ case "$LISP" in
     abcl)
         install_abcl
         ros use abcl/system
+        ;;
+    ecl)
+        install_ecl
+        ros use ecl/system
         ;;
     *)
         ros install $LISP

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -61,14 +61,18 @@ install_abcl () {
 ECL_TARBALL_URL="http://downloads.sourceforge.net/project/ecls/ecls/15.3/ecl-15.3.7.tgz"
 install_ecl () {
     fetch "$ECL_TARBALL_URL" "$HOME/ecl.tgz"
-    sudo tar -C / -xzf "$HOME/ecl.tgz"
+    extract -z "$HOME/ecl.tgz" "$HOME/ecl"
+    cd $HOME/ecl
+    ./configure
+    make
+    sudo make install
 }
 
 ALLEGRO_TARBALL_URL="http://www.franz.com/ftp/pub/acl90express/linux86/acl90express-linux-x86.bz2"
 install_allegro () {
     fetch "$ALLEGRO_TARBALL_URL" "$HOME/acl.bz2"
     extract -j "$HOME/acl.bz2" "$HOME/acl"
-    sudo ln -s "$HOME/acl/alisp" "/usr/local/bin"
+    sudo ln -s "$HOME/acl/alisp" "/usr/local/bin/alisp"
 }
 
 ROSWELL_TARBALL_PATH=$HOME/roswell.tar.gz

--- a/scripts/install-for-ci.sh
+++ b/scripts/install-for-ci.sh
@@ -24,6 +24,18 @@ extract () {
     tar -C "$destination" --strip-components=1 "$opt" -xf "$file"
 }
 
+install_script () {
+    path=$1; shift
+    tmp=$(mktemp)
+
+    for line; do
+        echo "$line" >> "$tmp"
+    done
+    chmod 755 "$tmp"
+
+    sudo mv "$tmp" "$path"
+}
+
 CMU_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.tar.bz2"
 CMU_EXTRA_TARBALL_URL="https://common-lisp.net/project/cmucl/downloads/snapshots/2015/07/cmucl-2015-07-x86-linux.extra.tar.bz2"
 install_cmucl () {
@@ -41,10 +53,8 @@ install_abcl () {
     sudo apt-get install default-jre
     fetch "$ABCL_TARBALL_URL" "$HOME/abcl.tar.gz"
     extract -z "$HOME/abcl.tar.gz" "$HOME/abcl"
-    sudo cat <<EOF >/usr/local/bin/abcl
-#!/bin/sh
-java -cp \"$HOME/abcl/abcl-contrib.jar\" -jar \"$HOME/abcl/abcl.jar\" \"\$@\"
-EOF
+    install_script "#!/bin/sh" \
+        "java -cp \"$HOME/abcl/abcl-contrib.jar\" -jar \"$HOME/abcl/abcl.jar\" \"\$@\""
 }
 
 ECL_TARBALL_URL="http://downloads.sourceforge.net/project/ecls/ecls/15.3/ecl-15.3.7.tgz"


### PR DESCRIPTION
This allows to run CI with CLISP, CMUCL, ABCL, ECL and Allegro CL.
If `$LISP` is one of below, the installer script installs corresponding implementation:

- clisp
- cmucl
- cmu (Same as cmucl)
- abcl
- ecl
- allegro
- alisp (Same as allegro)

ex) https://github.com/fukamachi/quri/blob/3f9bb50836cec41bfd45c2fe78327df2536538cf/.travis.yml

This requires 'sudo' if $LISP is clisp or abcl because they needs 'clisp' and 'default-jre' to be installed via APT.
If those packages are installed beforehand (ex 'addons' directive in .travis.yml), it doesn't require 'sudo'.

As ECL doesn't provide a binary package, it takes much time to CI for it.

The installs implementations under `~/.roswell/impls/system` (not `/usr/local` like cl-travis does) because this makes it easy to cache on CI services.