### PR TITLE
fix $ROSWELL_HOME dosen't work

### DIFF
--- a/src/util_dir.c
+++ b/src/util_dir.c
@@ -7,7 +7,7 @@ char* homedir(void) {
   env=getenv(c);
   s(c);
   if(env)
-    return append_trail_slash(env);
+    return append_trail_slash(subseq(env, 0, strlen(env)));
 #ifdef HAVE_WINDOWS_H
   TCHAR szAppData[MAX_PATH];
   if(SUCCEEDED(SHGetFolderPath(NULL, CSIDL_PROFILE, NULL, 0, szAppData)))


### PR DESCRIPTION
現状では，`ROSWELL_HOME=/path ros`を行うと以下のようなエラーを出力します．
; 環境依存です．
```
ros(65345,0x7fff735da300) malloc: *** error for object 0x7fff56412f75: pointer being freed was not allocated
*** set a breakpoint in malloc_error_break to debug
```

原因は，getenv()で取得したchar*をfree()したことです．
解決方法として，util_string.cのsubseqを使用してfree()で解放できる文字列を作成します．
