### PR TITLE
armhf platform fixes

### DIFF
--- a/src/cmd-install-sbcl-bin.c
+++ b/src/cmd-install-sbcl-bin.c
@@ -42,7 +42,10 @@ int sbcl_bin_download(struct install_options* param) {
   char* home=configdir();
   char* arch=arch_(param);
   do {
-    param->expand_path=cat(home,"src",SLASH,"sbcl","-",param->version,"-",arch,SLASH,NULL);
+    if (!(strcmp(arch, "armhf-linux")))
+      param->expand_path=cat(home,"src",SLASH,"sbcl","-",param->version,"-","arm-linux",SLASH,NULL);
+    else
+      param->expand_path=cat(home,"src",SLASH,"sbcl","-",param->version,"-",arch,SLASH,NULL);
     impls_sbcl_bin.uri=cat(SBCL_BIN_BASE_URI "sbcl-",param->version,
                            "-",arch,"-binary",sbcl_bin_extention(param),NULL);
     result = download(param);

--- a/src/util.c
+++ b/src/util.c
@@ -60,7 +60,7 @@ int delete_file(char* pathspec) {
   return ret==0;
 #else
 //  #error not implemented delete_file
-#endif  
+#endif
 }
 
 int rename_file(char* file,char* new_name) {
@@ -216,10 +216,10 @@ char* uname_m(void) {
     s(result);
     if(strcmp(result2,"0")!=0) {
       s(result2);
-      return q("armel");
+      return q("armhf");
     }else {
       s(result2);
-      return q("armhf");
+      return q("armel");
     }
   }
   return substitute_char('-','_',p2);


### PR DESCRIPTION
First change is to choose proper arm platform arch. When we have line 

    readelf -A  /proc/self/exe |grep Tag_ABI_VFP

it means, here is *armhf* not *armel*.
Second problem is with sbcl tarball. Sbcl creates arm tar file named

    sbcl-1.2.14-armhf-linux-binary.tar.bz2

but there is directory named

    sbcl-1.2.14-arm-linux

not armhf-linux! Unfortunatelly, problems with running sbcl still exist.